### PR TITLE
File archive

### DIFF
--- a/archive.c
+++ b/archive.c
@@ -85,13 +85,15 @@ int create_archive(const char *out_path, int n, char *files[])
         uint64_t filesize;
         if (!file_exists_and_size(files[i], &filesize)) {
             fprintf(stderr, "Error: File '%s' does not exist or is inaccessible.\n", files[i]);
-            // fclose(out);
             return -1;
         }
-        FILE *out = fopen(out_path, "wb");
-        if (!out) return -1;
-        cwa_header_t h = {{'C','W','A','1'}, (uint32_t)n};
-        fwrite(&h, sizeof h, 1, out);
+    }
+
+    FILE *out = fopen(out_path, "wb");
+    if (!out) return -1;
+    cwa_header_t h = {{'C','W','A','1'}, (uint32_t)n};
+    fwrite(&h, sizeof h, 1, out);
+    for (int i = 0; i < n; ++i) {
         uint8_t *raw; uint64_t raw_sz;
         if (read_file(files[i], &raw, &raw_sz)) { fclose(out); return -1; }
         uint8_t *cmp; uint64_t cmp_sz;
@@ -101,8 +103,8 @@ int create_archive(const char *out_path, int n, char *files[])
         fwrite(files[i], 1, eh.filename_len, out);
         fwrite(cmp, 1, cmp_sz, out);
         free(raw); free(cmp);
-        fclose(out);
     }
+    fclose(out);
     return 0;
 }
 

--- a/archive.c
+++ b/archive.c
@@ -81,19 +81,17 @@ static void *xmalloc(size_t n) { void *p = malloc(n); if (!p) { perror("malloc")
 
 int create_archive(const char *out_path, int n, char *files[])
 {
-    FILE *out = fopen(out_path, "wb");
-    if (!out) return -1;
-    cwa_header_t h = {{'C','W','A','1'}, (uint32_t)n};
-    fwrite(&h, sizeof h, 1, out);
-
     for (int i = 0; i < n; ++i) {
         uint64_t filesize;
         if (!file_exists_and_size(files[i], &filesize)) {
             fprintf(stderr, "Error: File '%s' does not exist or is inaccessible.\n", files[i]);
-            fclose(out);
+            // fclose(out);
             return -1;
         }
-
+        FILE *out = fopen(out_path, "wb");
+        if (!out) return -1;
+        cwa_header_t h = {{'C','W','A','1'}, (uint32_t)n};
+        fwrite(&h, sizeof h, 1, out);
         uint8_t *raw; uint64_t raw_sz;
         if (read_file(files[i], &raw, &raw_sz)) { fclose(out); return -1; }
         uint8_t *cmp; uint64_t cmp_sz;
@@ -103,8 +101,8 @@ int create_archive(const char *out_path, int n, char *files[])
         fwrite(files[i], 1, eh.filename_len, out);
         fwrite(cmp, 1, cmp_sz, out);
         free(raw); free(cmp);
+        fclose(out);
     }
-    fclose(out);
     return 0;
 }
 


### PR DESCRIPTION
This pull request introduces improvements to the `archive.c` file, focusing on code correctness, error handling, and compatibility. The most significant changes include fixing logical errors, improving error reporting, replacing outdated code patterns, and ensuring compatibility with modern standards.

### Code correctness and error handling:

* Added a new helper function `file_exists_and_size` to check file existence and retrieve its size, improving error handling when processing input files.
* Enhanced error reporting in `create_archive` to notify users when a file does not exist or is inaccessible, preventing silent failures.

### Code modernization:

* Replaced outdated `fseek` and `ftell` logic in `read_file` with `stat` for file size retrieval, simplifying and modernizing the code.
* Updated `list_archive` to use `PRIu64` for printing `uint64_t` values, ensuring compatibility with modern standards for portable code.

### Bug fixes:

* Fixed a logical error in `compress_rle` where a single `|` was mistakenly used instead of `||` for conditional checks.